### PR TITLE
#3 수강신청 기능 구현

### DIFF
--- a/API_SPECIFICATION.md
+++ b/API_SPECIFICATION.md
@@ -754,8 +754,7 @@ GET /api/v1/enrollments/courses?page=0&size=10&keyword=데이터베이스&depart
         "enrollment": {
           "current": 35,
           "max": 40,
-          "isFull": false,
-          "availableSeats": 5
+          "isFull": false
         },
         "isInCart": false,
         "isEnrolled": false,
@@ -788,7 +787,9 @@ Authorization: Bearer {accessToken}
           "name": "데이터베이스",
           "section": "01",
           "credits": 3,
-          "courseType": "전공필수"
+          "courseType": "전공필수",
+          "currentStudents": 25,
+          "maxStudents": 30,
         },
         "professor": {
           "id": 10,
@@ -988,11 +989,7 @@ Authorization: Bearer {accessToken}
         "courseName": "데이터베이스",
         "section": "01",
         "errorCode": "COURSE_FULL",
-        "message": "수강 정원이 마감되었습니다",
-        "enrollment": {
-          "current": 45,
-          "max": 45
-        }
+        "message": "수강 정원이 마감되었습니다"
       }
     ]
   },
@@ -1127,6 +1124,8 @@ Authorization: Bearer {accessToken}
           "courseName": "알고리즘",
           "section": "01",
           "credits": 3,
+          "currentStudents": 25,
+          "maxStudents": 30,
           "courseType": {
             "code": "MAJOR_REQ",
             "name": "전공필수"
@@ -1153,7 +1152,7 @@ Authorization: Bearer {accessToken}
 }
 ```
 
-### 9.9 수강신청 상세 조회
+### 9.9 강의 상세 조회
 ```http
 GET /api/v1/courses/{enrollmentId}
 Authorization: Bearer {accessToken}

--- a/src/api/courseApi.js
+++ b/src/api/courseApi.js
@@ -154,8 +154,40 @@ export const clearCarts = async () => {
  * @returns {Promise} 수강신청 결과
  */
 export const enrollFromCart = async (courseIds) => {
-  const response = await axiosInstance.post(`${BASE_URL}/api/v1/enrollments/cart`, {
+  const response = await axiosInstance.post(`${BASE_URL}/api/v1/enrollments/bulk`, {
     courseIds,
+  });
+  return response.data;
+};
+
+/**
+ * 내 수강신청 목록 조회
+ * @param {number|null} enrollmentPeriodId - 학기 수강신청 기간 ID (선택, 미입력시 현재 학기)
+ * @returns {Promise} 수강신청 목록 및 요약 정보
+ */
+export const getMyEnrollments = async (enrollmentPeriodId = null) => {
+  const queryParams = new URLSearchParams();
+  
+  if (enrollmentPeriodId) {
+    queryParams.append('enrollmentPeriodId', enrollmentPeriodId);
+  }
+
+  const url = queryParams.toString() 
+    ? `${BASE_URL}/api/v1/enrollments/my?${queryParams.toString()}`
+    : `${BASE_URL}/api/v1/enrollments/my`;
+    
+  const response = await axiosInstance.get(url);
+  return response.data;
+};
+
+/**
+ * 수강신청 취소 (bulk)
+ * @param {number[]} enrollmentIds - 수강신청 ID 배열
+ * @returns {Promise} 취소 결과
+ */
+export const cancelEnrollments = async (enrollmentIds) => {
+  const response = await axiosInstance.delete(`${BASE_URL}/api/v1/enrollments/bulk`, {
+    data: { enrollmentIds },
   });
   return response.data;
 };

--- a/src/domains/course/components/CartTab.jsx
+++ b/src/domains/course/components/CartTab.jsx
@@ -20,7 +20,7 @@ import { formatScheduleTime } from '../utils/scheduleUtils';
  */
 const CartTab = ({
   cart,
-  totalCredits,
+  cartCredits,
   registeredCredits,
   onRemoveFromCart,
   onClearAllCarts,
@@ -53,7 +53,8 @@ const CartTab = ({
                   <TableCell>과목명</TableCell>
                   <TableCell>교수</TableCell>
                   <TableCell>학점</TableCell>
-                  <TableCell>시간</TableCell>
+                  <TableCell>시간/강의실</TableCell>
+                  <TableCell align="center">정원</TableCell>
                   <TableCell align="center">제거</TableCell>
                 </TableRow>
               </TableHead>
@@ -68,6 +69,20 @@ const CartTab = ({
                       <Typography variant="caption">
                         {course.schedule?.map(formatScheduleTime).join(', ') || '-'}
                       </Typography>
+                      <br />
+                      <Typography variant="caption" color="text.secondary">
+                        {course.classroom || '-'}
+                      </Typography>
+                    </TableCell>
+                    <TableCell align="center">
+                      <Typography variant="body2">
+                        {course.currentStudents || 0}/{course.maxStudents || 0}
+                      </Typography>
+                      {course.isFull && (
+                        <Typography variant="caption" color="error" sx={{ display: 'block' }}>
+                          마감
+                        </Typography>
+                      )}
                     </TableCell>
                     <TableCell align="center">
                       <IconButton
@@ -86,10 +101,10 @@ const CartTab = ({
           <Box sx={{ mt: 3, flexShrink: 0 }}>
             <Box sx={{ textAlign: 'center', p: 2, bgcolor: 'primary.light', borderRadius: 2 }}>
               <Typography variant="body1" sx={{ color: 'white', mb: 1 }}>
-                총 {totalCredits}학점
+                총 {cartCredits}학점
               </Typography>
               <Typography variant="h3" sx={{ color: 'white', fontWeight: 700 }}>
-                {totalCredits}
+                {cartCredits}
               </Typography>
               <Typography variant="body1" sx={{ color: 'white' }}>
                 학점 ({cart.length}과목)
@@ -110,13 +125,13 @@ const CartTab = ({
               size="large"
               fullWidth
               onClick={onConfirmRegistration}
-              disabled={totalCredits === 0 || totalCredits + registeredCredits > 21}
+              disabled={cartCredits === 0 || cartCredits + registeredCredits > 21}
               sx={{ mt: 2 }}
             >
-              수강신청 확정
+              장바구니 일괄 수강신청
             </Button>
 
-            {totalCredits + registeredCredits > 21 && (
+            {cartCredits + registeredCredits > 21 && (
               <Alert severity="error" sx={{ mt: 2 }}>
                 최대 수강 가능 학점(21학점)을 초과했습니다.
               </Alert>

--- a/src/domains/course/components/CourseListTable.jsx
+++ b/src/domains/course/components/CourseListTable.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, memo } from 'react';
 import {
   Box,
   Typography,
@@ -13,17 +13,15 @@ import {
   IconButton,
   CircularProgress,
 } from '@mui/material';
-import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
-import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline';
-import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
-import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
-import AddIcon from '@mui/icons-material/Add';
-import { formatScheduleTime } from '../utils/scheduleUtils';
+import CancelDialog from './CourseListTable/CancelDialog';
+import EnrollDialog from './CourseListTable/EnrollDialog';
+import CourseTableRow from './CourseListTable/CourseTableRow';
+import CourseTablePagination from './CourseListTable/CourseTablePagination';
 
 /**
  * 과목 목록 테이블 컴포넌트
  */
-const CourseListTable = ({
+const CourseListTable = memo(({
   courses,
   loading,
   pagination,
@@ -33,7 +31,39 @@ const CourseListTable = ({
   onAddToCart,
   onRemoveFromCart,
   onEnroll,
+  onCancelEnrollment,
+  enrollDialogOpen,
+  pendingEnrollCourse,
+  onEnrollDialogClose,
+  onEnrollConfirm,
 }) => {
+  const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
+  const [selectedEnrollmentId, setSelectedEnrollmentId] = useState(null);
+  const [selectedCourseName, setSelectedCourseName] = useState('');
+
+  const handleCancelClick = (enrollmentId, courseName) => {
+    setSelectedEnrollmentId(enrollmentId);
+    setSelectedCourseName(courseName);
+    setCancelDialogOpen(true);
+  };
+
+  const handleCancelConfirm = () => {
+    if (selectedEnrollmentId && onCancelEnrollment) {
+      onCancelEnrollment(selectedEnrollmentId);
+    } else if (!selectedEnrollmentId) {
+      // enrollmentId가 없으면 경고 표시
+      console.warn('수강신청 ID를 찾을 수 없습니다.');
+    }
+    setCancelDialogOpen(false);
+    setSelectedEnrollmentId(null);
+    setSelectedCourseName('');
+  };
+
+  const handleCancelClose = () => {
+    setCancelDialogOpen(false);
+    setSelectedEnrollmentId(null);
+    setSelectedCourseName('');
+  };
   return (
     <Box sx={{ 
       flex: 1, 
@@ -120,99 +150,31 @@ const CourseListTable = ({
                 const isFull = course.isFull || course.currentStudents >= course.maxStudents;
                 const isInCart = cart.find((c) => c.id === course.id);
                 const isRegistered = registered.find((c) => c.id === course.id);
-                const canEnroll = course.canEnroll !== false; // false가 아닌 경우 모두 true로 처리
+                const isEnrolled = course.isEnrolled === true || isRegistered;
+                const canEnroll = course.canEnroll !== false;
 
                 return (
-                  <TableRow key={course.id}>
-                    <TableCell sx={{ px: 1 }}>{course.subjectCode}</TableCell>
-                    <TableCell sx={{ px: 1 }}>
-                      <Typography variant="body2" sx={{ fontWeight: 500, fontSize: '0.875rem' }}>
-                        {course.subjectName}
-                      </Typography>
-                    </TableCell>
-                    <TableCell sx={{ px: 1 }}>{course.professor}</TableCell>
-                    <TableCell sx={{ px: 1 }}>{course.credits}</TableCell>
-                    <TableCell sx={{ px: 1 }}>
-                      <Chip
-                        label={course.courseType}
-                        size="small"
-                        color={
-                          course.courseType.includes('필수') ? 'error' : 'primary'
-                        }
-                        variant="outlined"
-                        sx={{ fontSize: '0.7rem', height: '24px' }}
-                      />
-                    </TableCell>
-                    <TableCell sx={{ px: 1 }}>
-                      <Typography variant="caption" sx={{ fontSize: '0.7rem', lineHeight: 1.3, display: 'block' }}>
-                        {course.schedule?.map(formatScheduleTime).join(', ') || '-'}
-                      </Typography>
-                      <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.65rem', display: 'block', mt: 0.3 }}>
-                        {course.classroom}
-                      </Typography>
-                    </TableCell>
-                    <TableCell align="center" sx={{ px: 1 }}>
-                      <Chip
-                        label={`${course.currentStudents}/${course.maxStudents}`}
-                        size="small"
-                        color={isFull ? 'error' : 'default'}
-                        sx={{ fontSize: '0.7rem', height: '24px' }}
-                      />
-                    </TableCell>
-                    <TableCell align="center" sx={{ px: 1 }}>
-                      {!canEnroll ? (
-                        null
-                      ) : isRegistered ? (
-                        <Chip label="-" size="small" variant="outlined" sx={{ fontSize: '0.7rem', height: '24px' }} />
-                      ) : isInCart ? (
-                        <IconButton
-                          color="error"
-                          onClick={() => onRemoveFromCart(course.id)}
-                          size="small"
-                          title="장바구니에서 제거"
-                          sx={{ padding: '4px' }}
-                        >
-                          <RemoveCircleOutlineIcon fontSize="small" />
-                        </IconButton>
-                      ) : (
-                        <IconButton
-                          color="secondary"
-                          onClick={() => onAddToCart(course)}
-                          size="small"
-                          title="장바구니에 추가"
-                          sx={{ padding: '4px' }}
-                        >
-                          <ShoppingCartIcon fontSize="small" />
-                        </IconButton>
-                      )}
-                    </TableCell>
-                    <TableCell align="center" sx={{ px: 1 }}>
-                      {!canEnroll ? (
-                        null
-                      ) : isRegistered ? (
-                        <IconButton
-                          color="primary"
-                          disabled
-                          size="small"
-                          title="수강신청 완료"
-                          sx={{ padding: '4px' }}
-                        >
-                          <CheckCircleOutlineIcon fontSize="small" />
-                        </IconButton>
-                      ) : (
-                        <IconButton
-                          color="primary"
-                          onClick={() => onEnroll && onEnroll(course)}
-                          disabled={isFull}
-                          size="small"
-                          title={isFull ? '정원 초과' : '수강신청'}
-                          sx={{ padding: '4px' }}
-                        >
-                          <AddIcon fontSize="small" />
-                        </IconButton>
-                      )}
-                    </TableCell>
-                  </TableRow>
+                  <CourseTableRow
+                    key={course.id}
+                    course={course}
+                    isInCart={!!isInCart}
+                    isRegistered={!!isRegistered}
+                    isEnrolled={isEnrolled}
+                    canEnroll={canEnroll}
+                    isFull={isFull}
+                    onAddToCart={onAddToCart}
+                    onRemoveFromCart={onRemoveFromCart}
+                    onEnroll={onEnroll}
+                    onCancelClick={(course) => {
+                      const enrollment = registered.find((c) => c.id === course.id);
+                      const enrollmentId = enrollment?.enrollmentId || course.enrollmentId;
+                      if (enrollmentId) {
+                        handleCancelClick(enrollmentId, course.subjectName);
+                      } else {
+                        console.warn('수강신청 ID를 찾을 수 없습니다:', course);
+                      }
+                    }}
+                  />
                 );
               })
             )}
@@ -221,74 +183,118 @@ const CourseListTable = ({
       </TableContainer>
 
       {/* 페이지네이션 */}
-      {pagination.total > 0 && (
-        <Box sx={{ 
-          display: 'flex', 
-          justifyContent: 'center', 
-          alignItems: 'center',
-          mt: 2,
-          pt: 2,
-          pb: 1,
-          borderTop: '1px solid #e0e0e0',
-          flexShrink: 0,
-          minHeight: 56,
-          backgroundColor: '#ffffff',
-          gap: 1,
-        }}>
-          <Button
-            disabled={pagination.page === 0 || loading}
-            onClick={() => onPageChange(pagination.page - 1)}
-            size="small"
-          >
-            이전
-          </Button>
-          
-          {Array.from({ length: pagination.totalPages }, (_, i) => i).map((pageNum) => {
-            const currentPage = pagination.page;
-            const totalPages = pagination.totalPages;
-            
-            const showPage = 
-              pageNum === 0 ||
-              pageNum === totalPages - 1 ||
-              (pageNum >= currentPage - 4 && pageNum <= currentPage + 4);
-            
-            if (!showPage) {
-              if (pageNum === currentPage - 5 || pageNum === currentPage + 5) {
-                return (
-                  <Typography key={pageNum} sx={{ px: 1 }}>...</Typography>
-                );
-              }
-              return null;
-            }
-            
-            return (
-              <Button
-                key={pageNum}
-                variant={pageNum === pagination.page ? 'contained' : 'outlined'}
-                onClick={() => onPageChange(pageNum)}
-                disabled={loading}
-                size="small"
-                sx={{
-                  minWidth: 40,
-                  px: 1,
-                }}
-              >
-                {pageNum + 1}
-              </Button>
-            );
-          })}
-          
-          <Button
-            disabled={pagination.page >= pagination.totalPages - 1 || loading}
-            onClick={() => onPageChange(pagination.page + 1)}
-            size="small"
-          >
-            다음
-          </Button>
-        </Box>
-      )}
+      <CourseTablePagination
+        pagination={pagination}
+        loading={loading}
+        onPageChange={onPageChange}
+      />
+
+      {/* 취소 확인 다이얼로그 */}
+      <CancelDialog
+        open={cancelDialogOpen}
+        onClose={handleCancelClose}
+        onConfirm={handleCancelConfirm}
+        courseName={selectedCourseName}
+      />
+
+      {/* 수강신청 확인 다이얼로그 */}
+      <EnrollDialog
+        open={enrollDialogOpen}
+        onClose={onEnrollDialogClose}
+        onConfirm={onEnrollConfirm}
+        course={pendingEnrollCourse}
+      />
     </Box>
   );
-};
+}, (prevProps, nextProps) => {
+  // 실제로 변경된 props만 비교하여 불필요한 리렌더링 방지
+  
+  // 기본 props 비교
+  if (prevProps.loading !== nextProps.loading) {
+    return false;
+  }
+  if (prevProps.enrollDialogOpen !== nextProps.enrollDialogOpen) {
+    return false;
+  }
+  
+  // pagination 비교
+  if (
+    prevProps.pagination.page !== nextProps.pagination.page ||
+    prevProps.pagination.size !== nextProps.pagination.size ||
+    prevProps.pagination.total !== nextProps.pagination.total ||
+    prevProps.pagination.totalPages !== nextProps.pagination.totalPages
+  ) {
+    return false;
+  }
+  
+  // pendingEnrollCourse 비교
+  if (prevProps.pendingEnrollCourse?.id !== nextProps.pendingEnrollCourse?.id) {
+    return false;
+  }
+  
+  // 배열 길이 비교
+  if (prevProps.courses.length !== nextProps.courses.length) {
+    return false;
+  }
+  if (prevProps.cart.length !== nextProps.cart.length) {
+    return false;
+  }
+  if (prevProps.registered.length !== nextProps.registered.length) {
+    return false;
+  }
+  
+  // courses 배열 비교: ID와 주요 상태를 함께 비교
+  if (prevProps.courses.length > 0) {
+    const prevCoursesKey = prevProps.courses.map(c => 
+      `${c.id}:${c.isInCart}:${c.isEnrolled}:${c.isFull}:${c.currentStudents}`
+    ).join('|');
+    const nextCoursesKey = nextProps.courses.map(c => 
+      `${c.id}:${c.isInCart}:${c.isEnrolled}:${c.isFull}:${c.currentStudents}`
+    ).join('|');
+    if (prevCoursesKey !== nextCoursesKey) {
+      return false;
+    }
+  }
+  
+  // cart 배열의 ID 비교
+  const prevCartIds = prevProps.cart.map(c => c.id || c.cartId).sort().join(',');
+  const nextCartIds = nextProps.cart.map(c => c.id || c.cartId).sort().join(',');
+  if (prevCartIds !== nextCartIds) {
+    return false;
+  }
+  
+  // registered 배열의 ID 비교
+  const prevRegisteredIds = prevProps.registered.map(c => c.id).sort().join(',');
+  const nextRegisteredIds = nextProps.registered.map(c => c.id).sort().join(',');
+  if (prevRegisteredIds !== nextRegisteredIds) {
+    return false;
+  }
+  
+  // 함수 참조 비교 (useCallback으로 메모이제이션되어 있으므로 참조만 비교)
+  if (prevProps.onPageChange !== nextProps.onPageChange) {
+    return false;
+  }
+  if (prevProps.onAddToCart !== nextProps.onAddToCart) {
+    return false;
+  }
+  if (prevProps.onRemoveFromCart !== nextProps.onRemoveFromCart) {
+    return false;
+  }
+  if (prevProps.onEnroll !== nextProps.onEnroll) {
+    return false;
+  }
+  if (prevProps.onCancelEnrollment !== nextProps.onCancelEnrollment) {
+    return false;
+  }
+  if (prevProps.onEnrollDialogClose !== nextProps.onEnrollDialogClose) {
+    return false;
+  }
+  if (prevProps.onEnrollConfirm !== nextProps.onEnrollConfirm) {
+    return false;
+  }
+  
+  // 모든 props가 동일하면 리렌더링 방지
+  return true;
+});
 
 export default CourseListTable;

--- a/src/domains/course/components/CourseListTable/CancelDialog.jsx
+++ b/src/domains/course/components/CourseListTable/CancelDialog.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
+} from '@mui/material';
+
+/**
+ * 수강신청 취소 확인 다이얼로그
+ */
+const CancelDialog = ({
+  open,
+  onClose,
+  onConfirm,
+  courseName,
+}) => {
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      aria-labelledby="cancel-dialog-title"
+      aria-describedby="cancel-dialog-description"
+    >
+      <DialogTitle id="cancel-dialog-title">
+        수강신청 취소 확인
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText id="cancel-dialog-description">
+          정말로 <strong>{courseName}</strong> 과목의 수강신청을 취소하시겠습니까?
+          <br />
+          취소 후에는 다시 신청해야 합니다.
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} color="inherit">
+          아니오
+        </Button>
+        <Button onClick={onConfirm} color="error" variant="contained" autoFocus>
+          취소하기
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default CancelDialog;
+

--- a/src/domains/course/components/CourseListTable/CourseTablePagination.jsx
+++ b/src/domains/course/components/CourseListTable/CourseTablePagination.jsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import {
+  Box,
+  Button,
+  Typography,
+} from '@mui/material';
+
+/**
+ * 강의 목록 테이블 페이지네이션 컴포넌트
+ */
+const CourseTablePagination = ({
+  pagination,
+  loading,
+  onPageChange,
+}) => {
+  if (pagination.total <= 0) return null;
+
+  return (
+    <Box sx={{ 
+      display: 'flex', 
+      justifyContent: 'center', 
+      alignItems: 'center',
+      mt: 2,
+      pt: 2,
+      pb: 1,
+      borderTop: '1px solid #e0e0e0',
+      flexShrink: 0,
+      minHeight: 56,
+      backgroundColor: '#ffffff',
+      gap: 1,
+    }}>
+      <Button
+        disabled={pagination.page === 0 || loading}
+        onClick={() => onPageChange(pagination.page - 1)}
+        size="small"
+      >
+        이전
+      </Button>
+      
+      {Array.from({ length: pagination.totalPages }, (_, i) => i).map((pageNum) => {
+        const currentPage = pagination.page;
+        const totalPages = pagination.totalPages;
+        
+        const showPage = 
+          pageNum === 0 ||
+          pageNum === totalPages - 1 ||
+          (pageNum >= currentPage - 4 && pageNum <= currentPage + 4);
+        
+        if (!showPage) {
+          if (pageNum === currentPage - 5 || pageNum === currentPage + 5) {
+            return (
+              <Typography key={pageNum} sx={{ px: 1 }}>...</Typography>
+            );
+          }
+          return null;
+        }
+        
+        return (
+          <Button
+            key={pageNum}
+            variant={pageNum === pagination.page ? 'contained' : 'outlined'}
+            onClick={() => onPageChange(pageNum)}
+            disabled={loading}
+            size="small"
+            sx={{
+              minWidth: 40,
+              px: 1,
+            }}
+          >
+            {pageNum + 1}
+          </Button>
+        );
+      })}
+      
+      <Button
+        disabled={pagination.page >= pagination.totalPages - 1 || loading}
+        onClick={() => onPageChange(pagination.page + 1)}
+        size="small"
+      >
+        다음
+      </Button>
+    </Box>
+  );
+};
+
+export default CourseTablePagination;
+

--- a/src/domains/course/components/CourseListTable/CourseTableRow.jsx
+++ b/src/domains/course/components/CourseListTable/CourseTableRow.jsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import {
+  TableRow,
+  TableCell,
+  Typography,
+  Chip,
+  IconButton,
+} from '@mui/material';
+import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline';
+import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
+import AddIcon from '@mui/icons-material/Add';
+import { formatScheduleTime } from '../../utils/scheduleUtils';
+
+/**
+ * 강의 목록 테이블 행 컴포넌트
+ */
+const CourseTableRow = ({
+  course,
+  isInCart,
+  isRegistered,
+  isEnrolled,
+  canEnroll,
+  isFull,
+  onAddToCart,
+  onRemoveFromCart,
+  onEnroll,
+  onCancelClick,
+}) => {
+  return (
+    <TableRow key={course.id}>
+      <TableCell sx={{ px: 1 }}>{course.subjectCode}</TableCell>
+      <TableCell sx={{ px: 1 }}>
+        <Typography variant="body2" sx={{ fontWeight: 500, fontSize: '0.875rem' }}>
+          {course.subjectName}
+        </Typography>
+      </TableCell>
+      <TableCell sx={{ px: 1 }}>{course.professor}</TableCell>
+      <TableCell sx={{ px: 1 }}>{course.credits}</TableCell>
+      <TableCell sx={{ px: 1 }}>
+        <Chip
+          label={course.courseType}
+          size="small"
+          color={
+            course.courseType.includes('필수') ? 'error' : 'primary'
+          }
+          variant="outlined"
+          sx={{ fontSize: '0.7rem', height: '24px' }}
+        />
+      </TableCell>
+      <TableCell sx={{ px: 1 }}>
+        <Typography variant="caption" sx={{ fontSize: '0.7rem', lineHeight: 1.3, display: 'block' }}>
+          {course.schedule?.map(formatScheduleTime).join(', ') || '-'}
+        </Typography>
+        <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.65rem', display: 'block', mt: 0.3 }}>
+          {course.classroom}
+        </Typography>
+      </TableCell>
+      <TableCell align="center" sx={{ px: 1 }}>
+        <Chip
+          label={`${course.currentStudents}/${course.maxStudents}`}
+          size="small"
+          color={isFull ? 'error' : 'default'}
+          sx={{ fontSize: '0.7rem', height: '24px' }}
+        />
+      </TableCell>
+      <TableCell align="center" sx={{ px: 1 }}>
+        {!canEnroll ? (
+          null
+        ) : isEnrolled ? (
+          null // 신청 완료된 과목은 장바구니 버튼 숨김
+        ) : isInCart ? (
+          <IconButton
+            color="error"
+            onClick={() => onRemoveFromCart(course.id)}
+            size="small"
+            title="장바구니에서 제거"
+            sx={{ padding: '4px' }}
+          >
+            <RemoveCircleOutlineIcon fontSize="small" />
+          </IconButton>
+        ) : (
+          <IconButton
+            color="secondary"
+            onClick={() => onAddToCart(course)}
+            size="small"
+            title="장바구니에 추가"
+            sx={{ padding: '4px' }}
+          >
+            <ShoppingCartIcon fontSize="small" />
+          </IconButton>
+        )}
+      </TableCell>
+      <TableCell align="center" sx={{ px: 1 }}>
+        {isEnrolled ? (
+          // 신청 완료된 과목은 canEnroll과 관계없이 취소 버튼 표시
+          <IconButton
+            color="error"
+            onClick={() => onCancelClick(course)}
+            size="small"
+            title="수강신청 취소"
+            sx={{ padding: '4px' }}
+          >
+            <RemoveCircleOutlineIcon fontSize="small" />
+          </IconButton>
+        ) : !canEnroll ? (
+          null
+        ) : (
+          <IconButton
+            color="primary"
+            onClick={() => onEnroll && onEnroll(course)}
+            disabled={isFull}
+            size="small"
+            title={isFull ? '정원 초과' : '수강신청'}
+            sx={{ padding: '4px' }}
+          >
+            <AddIcon fontSize="small" />
+          </IconButton>
+        )}
+      </TableCell>
+    </TableRow>
+  );
+};
+
+export default CourseTableRow;
+

--- a/src/domains/course/components/CourseListTable/EnrollDialog.jsx
+++ b/src/domains/course/components/CourseListTable/EnrollDialog.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Box,
+  Typography,
+} from '@mui/material';
+import { formatScheduleTime } from '../../utils/scheduleUtils';
+
+/**
+ * 수강신청 확인 다이얼로그
+ */
+const EnrollDialog = ({
+  open,
+  onClose,
+  onConfirm,
+  course,
+}) => {
+  if (!course) return null;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      aria-labelledby="enroll-dialog-title"
+      aria-describedby="enroll-dialog-description"
+      maxWidth="sm"
+      fullWidth={true}
+      sx={{
+        '& .MuiDialog-paper': {
+          minWidth: '400px',
+          maxWidth: '500px',
+        }
+      }}
+    >
+      <DialogTitle id="enroll-dialog-title">
+        수강신청 확인
+      </DialogTitle>
+      <DialogContent>
+        <Box id="enroll-dialog-description">
+          <Typography variant="body1" component="div" sx={{ mb: 1, fontWeight: 600 }}>
+            {course.subjectName} ({course.subjectCode})
+          </Typography>
+          <Typography variant="body2" component="div" color="text.secondary">
+            교수: {course.professor || '-'}
+          </Typography>
+          <Typography variant="body2" component="div" color="text.secondary">
+            학점: {course.credits}학점
+          </Typography>
+          <Typography variant="body2" component="div" color="text.secondary">
+            이수구분: {course.courseType}
+          </Typography>
+          <Typography variant="body2" component="div" color="text.secondary">
+            시간: {course.schedule?.map(formatScheduleTime).join(', ') || '-'}
+          </Typography>
+          <Typography variant="body2" component="div" color="text.secondary">
+            강의실: {course.classroom}
+          </Typography>
+          <Typography variant="body2" component="div" color="text.secondary" sx={{ mt: 2 }}>
+            정말 수강신청하시겠습니까?
+          </Typography>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} color="inherit">
+          취소
+        </Button>
+        <Button 
+          onClick={() => onConfirm(course)} 
+          variant="contained" 
+          color="primary"
+          autoFocus
+        >
+          신청
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default EnrollDialog;
+

--- a/src/domains/course/components/EnrollmentSummary.jsx
+++ b/src/domains/course/components/EnrollmentSummary.jsx
@@ -15,11 +15,10 @@ import {
  */
 const EnrollmentSummary = ({
   registeredCredits,
-  totalCredits,
+  cartCredits,
   registeredCount,
   cartCount,
 }) => {
-  const total = registeredCredits + totalCredits;
 
   return (
     <Card sx={{  display: 'flex', flexDirection: 'column' }}>
@@ -51,7 +50,7 @@ const EnrollmentSummary = ({
                   장바구니
                 </Typography>
                 <Typography variant="h5" sx={{ color: 'white', fontSize: '2rem'}}>
-                  {totalCredits}
+                  {cartCredits}
                 </Typography>
                 <Typography variant="body2" sx={{ color: 'white', fontSize: '1.4rem' }}>
                   학점 ({cartCount}과목)
@@ -67,32 +66,41 @@ const EnrollmentSummary = ({
           <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5, fontSize: '1.4rem' }}>
             총 신청 학점
           </Typography>
-          <Typography variant="h4" sx={{ fontSize: '2rem', color: total > 21 ? 'error.main' : 'text.primary' }}>
-            {total}
-          </Typography>
-          <Typography variant="body1" color="text.secondary" sx={{ fontSize: '1.4rem' }}>
-            / 21 학점
-          </Typography>
+          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.5 }}>
+            <Box sx={{ display: 'flex', alignItems: 'baseline', justifyContent: 'center', gap: 0.5 }}>
+              <Typography variant="h4" sx={{ fontSize: '2rem', color: registeredCredits > 21 ? 'error.main' : 'text.primary' }}>
+                {registeredCredits}
+              </Typography>
+              {cartCredits > 0 && (
+                <Typography variant="body1" color="text.secondary" sx={{ fontSize: '1.2rem' }}>
+                  ({cartCredits})
+                </Typography>
+              )}
+            </Box>
+            <Typography variant="body1" color="text.secondary" sx={{ fontSize: '1.4rem' }}>
+              / 21 학점
+            </Typography>
+          </Box>
 
           <LinearProgress
             variant="determinate"
-            value={Math.min((total / 21) * 100, 100)}
+            value={Math.min((registeredCredits / 21) * 100, 100)}
             sx={{
               mt: 1,
               height: 8,
               borderRadius: 4,
               bgcolor: 'grey.300'
             }}
-            color={total > 21 ? 'error' : total > 18 ? 'warning' : 'primary'}
+            color={registeredCredits > 21 ? 'error' : registeredCredits > 18 ? 'warning' : 'primary'}
           />
         </Box>
 
-        {total > 21 && (
+        {registeredCredits > 21 && (
           <Alert severity="error" sx={{ mt: 2 }}>
             최대 수강 가능 학점(21학점)을 초과했습니다!
           </Alert>
         )}
-        {total > 18 && total <= 21 && (
+        {registeredCredits > 18 && registeredCredits <= 21 && (
           <Alert severity="warning" sx={{ mt: 2 }}>
             18학점을 초과했습니다. 신중히 선택하세요.
           </Alert>

--- a/src/domains/course/components/RegisteredTab.jsx
+++ b/src/domains/course/components/RegisteredTab.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Box,
   Typography,
@@ -10,14 +10,46 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
 } from '@mui/material';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline';
 import { formatScheduleTime } from '../utils/scheduleUtils';
 
 /**
  * 신청 완료 탭 컴포넌트
  */
-const RegisteredTab = ({ registered }) => {
+const RegisteredTab = ({ registered, onCancelEnrollment }) => {
+  const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
+  const [selectedEnrollmentId, setSelectedEnrollmentId] = useState(null);
+  const [selectedCourseName, setSelectedCourseName] = useState('');
+
+  const handleCancelClick = (enrollmentId, courseName) => {
+    setSelectedEnrollmentId(enrollmentId);
+    setSelectedCourseName(courseName);
+    setCancelDialogOpen(true);
+  };
+
+  const handleCancelConfirm = () => {
+    if (selectedEnrollmentId && onCancelEnrollment) {
+      onCancelEnrollment(selectedEnrollmentId);
+    }
+    setCancelDialogOpen(false);
+    setSelectedEnrollmentId(null);
+    setSelectedCourseName('');
+  };
+
+  const handleCancelClose = () => {
+    setCancelDialogOpen(false);
+    setSelectedEnrollmentId(null);
+    setSelectedCourseName('');
+  };
   return (
     <Box sx={{ 
       height: '100%',
@@ -40,6 +72,8 @@ const RegisteredTab = ({ registered }) => {
                 <TableCell>교수</TableCell>
                 <TableCell>학점</TableCell>
                 <TableCell>시간/강의실</TableCell>
+                <TableCell align="center">정원</TableCell>
+                <TableCell align="center">취소</TableCell>
                 <TableCell align="center">상태</TableCell>
               </TableRow>
             </TableHead>
@@ -60,6 +94,41 @@ const RegisteredTab = ({ registered }) => {
                     </Typography>
                   </TableCell>
                   <TableCell align="center">
+                    {course.currentStudents !== undefined && course.maxStudents !== undefined ? (
+                      <>
+                        <Typography variant="body2">
+                          {course.currentStudents}/{course.maxStudents}
+                        </Typography>
+                        {course.isFull && (
+                          <Typography variant="caption" color="error" sx={{ display: 'block' }}>
+                            마감
+                          </Typography>
+                        )}
+                      </>
+                    ) : (
+                      <Typography variant="body2" color="text.secondary">
+                        -
+                      </Typography>
+                    )}
+                  </TableCell>
+                  <TableCell align="center">
+                    {course.canCancel !== false && course.enrollmentId ? (
+                      <IconButton
+                        color="error"
+                        onClick={() => handleCancelClick(course.enrollmentId, course.subjectName)}
+                        size="small"
+                        title="수강신청 취소"
+                        sx={{ padding: '4px' }}
+                      >
+                        <RemoveCircleOutlineIcon fontSize="small" />
+                      </IconButton>
+                    ) : (
+                      <Typography variant="caption" color="text.secondary">
+                        -
+                      </Typography>
+                    )}
+                  </TableCell>
+                  <TableCell align="center">
                     <Chip
                       icon={<CheckCircleIcon />}
                       label="신청완료"
@@ -73,6 +142,33 @@ const RegisteredTab = ({ registered }) => {
           </Table>
         </TableContainer>
       )}
+
+      {/* 취소 확인 다이얼로그 */}
+      <Dialog
+        open={cancelDialogOpen}
+        onClose={handleCancelClose}
+        aria-labelledby="cancel-dialog-title"
+        aria-describedby="cancel-dialog-description"
+      >
+        <DialogTitle id="cancel-dialog-title">
+          수강신청 취소 확인
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText id="cancel-dialog-description">
+            정말로 <strong>{selectedCourseName}</strong> 과목의 수강신청을 취소하시겠습니까?
+            <br />
+            취소 후에는 다시 신청해야 합니다.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCancelClose} color="inherit">
+            아니오
+          </Button>
+          <Button onClick={handleCancelConfirm} color="error" variant="contained" autoFocus>
+            취소하기
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 };

--- a/src/domains/course/components/TabPanel.jsx
+++ b/src/domains/course/components/TabPanel.jsx
@@ -1,13 +1,12 @@
-import React from 'react';
+import React, { memo } from 'react';
 import { Box } from '@mui/material';
 
 /**
  * 탭 패널 컴포넌트
+ * display: none을 사용하여 언마운트하지 않고 숨김 처리 (리렌더링 방지)
  */
-function TabPanel({ children, value, index }) {
-  if (value !== index) {
-    return null;
-  }
+const TabPanel = memo(({ children, value, index }) => {
+  const isActive = value === index;
 
   return (
     <Box
@@ -16,7 +15,7 @@ function TabPanel({ children, value, index }) {
       aria-labelledby={`tab-${index}`}
       sx={{ 
         flex: 1,
-        display: 'flex', 
+        display: isActive ? 'flex' : 'none', 
         flexDirection: 'column', 
         minHeight: 0, 
         height: '100%',
@@ -27,6 +26,8 @@ function TabPanel({ children, value, index }) {
       {children}
     </Box>
   );
-}
+});
+
+TabPanel.displayName = 'TabPanel';
 
 export default TabPanel;

--- a/src/domains/course/components/ToastManager.jsx
+++ b/src/domains/course/components/ToastManager.jsx
@@ -1,0 +1,123 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Snackbar } from '@mui/material';
+import MuiAlert from '@mui/material/Alert';
+
+/**
+ * Toast 메시지 관리 컴포넌트
+ * toast ref를 받아서 리렌더링 없이 토스트를 표시
+ */
+const ToastManager = ({ toastRef }) => {
+  const [toastQueue, setToastQueue] = useState([]);
+  const [currentToast, setCurrentToast] = useState({ open: false, message: '', severity: 'error' });
+  const currentToastRef = useRef(currentToast);
+  const prevToastRef = useRef({ open: false, message: '', severity: 'error' });
+
+  // currentToast 변경 시 ref 업데이트
+  useEffect(() => {
+    currentToastRef.current = currentToast;
+  }, [currentToast]);
+
+  // toast 변경 감지 (polling 방식으로 리렌더링 방지)
+  useEffect(() => {
+    const checkToast = () => {
+      if (!toastRef?.current) return;
+      
+      const toast = toastRef.current;
+      
+      // toast가 닫혔을 때 prevToastRef 업데이트
+      if (!toast.open) {
+        if (prevToastRef.current.open) {
+          // 깊은 복사로 저장하여 참조 문제 방지
+          prevToastRef.current = { open: false, message: '', severity: 'error' };
+        }
+        return; // 닫힌 상태에서는 더 이상 처리하지 않음
+      }
+      
+      // toast가 열렸을 때만 처리
+      if (toast.open && toast.message) {
+        // 이미 표시한 토스트인지 확인 (메시지와 severity로 비교)
+        const isAlreadyShown = 
+          prevToastRef.current.open &&
+          prevToastRef.current.message === toast.message &&
+          prevToastRef.current.severity === toast.severity;
+        
+        // 이미 표시한 토스트는 무시
+        if (isAlreadyShown) {
+          return;
+        }
+        
+        // 닫힌 상태에서 열린 상태로 변경된 경우만 처리
+        const isNewToast = !prevToastRef.current.open && toast.open;
+        
+        // 새로운 토스트인 경우에만 처리
+        if (isNewToast) {
+          // 깊은 복사로 저장하여 참조 문제 방지
+          prevToastRef.current = { 
+            open: toast.open, 
+            message: toast.message, 
+            severity: toast.severity 
+          };
+          
+          // 토스트를 표시한 후 toastRef를 닫힌 상태로 업데이트 (같은 토스트가 다시 오지 않도록)
+          if (toastRef?.current) {
+            toastRef.current = { ...toastRef.current, open: false };
+          }
+          
+          if (currentToastRef.current.open) {
+            // 현재 토스트가 열려있으면 기존 큐를 비우고 마지막 토스트만 표시
+            setTimeout(() => {
+              setToastQueue([]); // 기존 큐 비우기
+              setCurrentToast({ ...toast }); // 마지막 토스트로 교체 (깊은 복사)
+            }, 0);
+          } else {
+            // 바로 표시
+            setTimeout(() => {
+              setCurrentToast({ ...toast }); // 깊은 복사
+            }, 0);
+          }
+        }
+      }
+    };
+    
+    // 주기적으로 체크 (리렌더링 없이)
+    const interval = setInterval(checkToast, 50);
+    checkToast(); // 즉시 한 번 체크
+    
+    return () => clearInterval(interval);
+  }, [toastRef]);
+
+  // 토스트가 완전히 사라진 후 다음 메시지 표시
+  const handleToastExited = () => {
+    // prevToastRef 초기화하여 같은 메시지를 다시 표시할 수 있도록
+    prevToastRef.current = { open: false, message: '', severity: 'error' };
+    
+    if (toastQueue.length > 0) {
+      const nextToast = toastQueue[0];
+      setToastQueue(prev => prev.slice(1));
+      setCurrentToast(nextToast);
+    } else {
+      setCurrentToast({ open: false, message: '', severity: 'error' });
+    }
+  };
+
+  return (
+    <Snackbar
+      open={currentToast.open}
+      autoHideDuration={4000}
+      onClose={() => setCurrentToast(prev => ({ ...prev, open: false }))}
+      TransitionProps={{ onExited: handleToastExited }}
+      anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+    >
+      <MuiAlert
+        onClose={() => setCurrentToast(prev => ({ ...prev, open: false }))}
+        severity={currentToast.severity}
+        sx={{ width: '100%' }}
+      >
+        {currentToast.message}
+      </MuiAlert>
+    </Snackbar>
+  );
+};
+
+export default ToastManager;
+

--- a/src/domains/course/constants/courseTypes.js
+++ b/src/domains/course/constants/courseTypes.js
@@ -1,0 +1,19 @@
+/**
+ * 이수구분 코드 매핑
+ */
+export const courseTypeMap = {
+  '전공필수': 1,
+  '전공선택': 2,
+  '교양필수': 3,
+  '교양선택': 4,
+};
+
+/**
+ * 이수구분 코드를 숫자로 변환
+ * @param {string} courseTypeName - 이수구분 이름
+ * @returns {number|null} 이수구분 코드
+ */
+export const getCourseTypeCode = (courseTypeName) => {
+  return courseTypeMap[courseTypeName] || null;
+};
+

--- a/src/domains/course/hooks/useCourseRegistration.js
+++ b/src/domains/course/hooks/useCourseRegistration.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { 
   getCurrentEnrollmentPeriod, 
   getCourses,
@@ -7,17 +7,13 @@ import {
   removeFromCarts,
   clearCarts,
   enrollFromCart,
+  getMyEnrollments,
+  cancelEnrollments,
 } from '../../../api/courseApi';
 import { checkScheduleConflict } from '../utils/scheduleUtils';
 import { isCreditLimitExceeded, calculateTotalCredits } from '../utils/creditUtils';
-
-// 이수구분 코드 매핑
-const courseTypeMap = {
-  '전공필수': 1,
-  '전공선택': 2,
-  '교양필수': 3,
-  '교양선택': 4,
-};
+import { courseTypeMap } from '../constants/courseTypes';
+import { transformCourseData, transformCartData, transformEnrollmentData } from '../transformers/courseTransformers';
 
 /**
  * 수강신청 관련 커스텀 훅
@@ -46,53 +42,11 @@ const useCourseRegistration = () => {
     totalPages: 0,
   });
 
-
-  // API 응답 데이터를 UI 형식으로 변환
-  const transformCourseData = (apiCourse) => {
-
-
-    const transformed = {
-      id: apiCourse.id,
-      subjectCode: apiCourse.courseCode,
-      subjectName: apiCourse.courseName,
-      professor: apiCourse.professor?.name || '',
-      department: apiCourse.department?.name || '',
-      departmentId: apiCourse.department?.id || null,
-      courseType: apiCourse.courseType?.name || '',
-      courseTypeCode: apiCourse.courseType?.code || '',
-      credits: apiCourse.credits,
-      currentStudents: apiCourse.enrollment?.current || 0,
-      maxStudents: apiCourse.enrollment?.max || 0,
-      isFull: apiCourse.enrollment?.isFull || false,
-      schedule: apiCourse.schedule || [],
-      classroom: apiCourse.schedule?.[0]?.classroom || '',
-      isInCart: apiCourse.isInCart || false,
-      isEnrolled: apiCourse.isEnrolled || false,
-      canEnroll: apiCourse.canEnroll, // API 응답값 그대로 사용
-    };
+  // 수강신청 확인 다이얼로그 상태
+  const [enrollDialogOpen, setEnrollDialogOpen] = useState(false);
+  const [pendingEnrollCourse, setPendingEnrollCourse] = useState(null);
 
 
-    return transformed;
-  };
-
-  // 장바구니 API 응답 데이터를 UI 형식으로 변환
-  const transformCartData = (cartItem) => {
-    return {
-      cartId: cartItem.cartId,
-      id: cartItem.course?.id,
-      subjectCode: cartItem.course?.code,
-      subjectName: cartItem.course?.name,
-      professor: cartItem.professor?.name || '',
-      credits: cartItem.course?.credits || 0,
-      courseType: cartItem.course?.courseType || '',
-      schedule: cartItem.schedule || [],
-      classroom: cartItem.schedule?.[0]?.classroom || '',
-      currentStudents: cartItem.enrollment?.current || 0,
-      maxStudents: cartItem.enrollment?.max || 0,
-      isFull: cartItem.enrollment?.isFull || false,
-      addedAt: cartItem.addedAt,
-    };
-  };
 
   // 수강신청 기간 조회
   useEffect(() => {
@@ -118,19 +72,38 @@ const useCourseRegistration = () => {
     fetchEnrollmentPeriod();
   }, []);
 
-  // 검색어를 ref로 관리하여 debounce 시 최신 값 참조
+  // 검색어와 필터를 ref로 관리하여 fetchCourses 재생성 방지
   const searchTermRef = useRef(searchTerm);
+  const selectedDepartmentRef = useRef(selectedDepartment);
+  const selectedCourseTypeRef = useRef(selectedCourseType);
+  const selectedCreditsRef = useRef(selectedCredits);
   
   useEffect(() => {
     searchTermRef.current = searchTerm;
   }, [searchTerm]);
+  
+  useEffect(() => {
+    selectedDepartmentRef.current = selectedDepartment;
+  }, [selectedDepartment]);
+  
+  useEffect(() => {
+    selectedCourseTypeRef.current = selectedCourseType;
+  }, [selectedCourseType]);
+  
+  useEffect(() => {
+    selectedCreditsRef.current = selectedCredits;
+  }, [selectedCredits]);
 
   // 강의 목록 조회
-  const fetchCourses = useCallback(async (page = null) => {
+  const fetchCourses = useCallback(async (page = null, silent = false) => {
     if (!enrollmentPeriodId) return;
 
+    console.log('[API 호출] fetchCourses', { page, silent, timestamp: new Date().toISOString() });
+
     try {
-      setLoading(true);
+      if (!silent) {
+        setLoading(true);
+      }
       setError(null);
 
       const currentPage = page !== null ? page : pagination.page;
@@ -147,24 +120,24 @@ const useCourseRegistration = () => {
         params.keyword = searchTermRef.current.trim();
       }
 
-      // 학과 필터
-      if (selectedDepartment !== 'all') {
-        params.departmentId = parseInt(selectedDepartment);
+      // 학과 필터 (ref 사용)
+      if (selectedDepartmentRef.current !== 'all') {
+        params.departmentId = parseInt(selectedDepartmentRef.current);
       }
 
-      // 이수구분 필터
-      if (selectedCourseType !== 'all') {
-        params.courseType = courseTypeMap[selectedCourseType];
+      // 이수구분 필터 (ref 사용)
+      if (selectedCourseTypeRef.current !== 'all') {
+        params.courseType = courseTypeMap[selectedCourseTypeRef.current];
       }
 
-      // 학점 필터
-      if (selectedCredits !== 'all') {
-        params.credits = parseInt(selectedCredits);
+      // 학점 필터 (ref 사용)
+      if (selectedCreditsRef.current !== 'all') {
+        params.credits = parseInt(selectedCreditsRef.current);
       }
 
       const response = await getCourses(params);
 
-
+      console.log('[API 응답] fetchCourses', { response, timestamp: new Date().toISOString() });
 
       if (response.success && response.data) {
         const transformedCourses = response.data.content?.map(transformCourseData) || [];
@@ -190,31 +163,60 @@ const useCourseRegistration = () => {
       setError(err.message || '강의 목록을 불러오는 중 오류가 발생했습니다.');
       setCourses([]);
     } finally {
-      setLoading(false);
+      if (!silent) {
+        setLoading(false);
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enrollmentPeriodId, selectedDepartment, selectedCourseType, selectedCredits, sortBy, pagination.size, courseTypeMap]);
+  }, [enrollmentPeriodId, sortBy, pagination.size]); // 필터는 ref로 관리하여 재생성 방지
 
-  // enrollmentPeriodId가 설정되면 강의 목록 및 장바구니 조회
+  // enrollmentPeriodId가 설정되면 강의 목록, 장바구니, 수강신청 목록 조회
   useEffect(() => {
-    if (enrollmentPeriodId) {
-      fetchCourses(0); // 명시적으로 page 0 전달
-      fetchCarts(); // 장바구니 조회
+    if (enrollmentPeriodId && !initialLoadCompleteRef.current) {
+      // 초기 로딩 시 loading 상태를 한 번만 관리
+      setLoading(true);
+      initialLoadCompleteRef.current = false; // 초기 로딩 시작
+      
+      // 병렬로 실행하되, 모든 API 완료 후 loading을 false로 설정
+      Promise.all([
+        fetchCourses(0, true), // silent 모드로 실행 (loading 변경 없음)
+        fetchCarts(), // 장바구니 조회 (loading 변경 없음)
+        fetchEnrollments(enrollmentPeriodId), // 수강신청 목록 조회 (loading 변경 없음)
+      ]).then(() => {
+        setLoading(false);
+        initialLoadCompleteRef.current = true; // 초기 로딩 완료
+      }).catch(err => {
+        console.error('초기 데이터 로딩 실패:', err);
+        setLoading(false);
+        initialLoadCompleteRef.current = true; // 에러 발생 시에도 완료로 표시
+      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enrollmentPeriodId]); // fetchCourses, fetchCarts는 ref로 관리하여 무한 루프 방지
+  }, [enrollmentPeriodId]); // fetchCourses, fetchCarts, fetchEnrollments는 ref로 관리하여 무한 루프 방지
 
-  // 검색어 debounce
+  // 초기 로딩 완료 플래그
+  const initialLoadCompleteRef = useRef(false);
+  
+  // 검색어 debounce (초기 로딩 완료 후에만 실행)
   useEffect(() => {
-    if (!enrollmentPeriodId) return;
+    if (!enrollmentPeriodId || !initialLoadCompleteRef.current) return;
+    // if (searchTerm === '') return; // 빈 검색어는 무시 (초기 로딩과 중복 방지)
 
     const timer = setTimeout(() => {
       setPagination(prev => ({ ...prev, page: 0 }));
-      fetchCourses(0);
+      fetchCoursesRef.current(0); // ref 사용하여 불필요한 API 호출 방지
     }, 500);
 
     return () => clearTimeout(timer);
-  }, [searchTerm, enrollmentPeriodId, fetchCourses]);
+  }, [searchTerm, enrollmentPeriodId]); // fetchCourses 제거하여 리렌더링 시 불필요한 API 호출 방지
+  
+  // 필터 변경 시 강의 목록 다시 조회 (초기 로딩 완료 후에만)
+  useEffect(() => {
+    if (!enrollmentPeriodId || !initialLoadCompleteRef.current) return;
+    
+    setPagination(prev => ({ ...prev, page: 0 }));
+    fetchCoursesRef.current(0);
+  }, [selectedDepartment, selectedCourseType, selectedCredits, enrollmentPeriodId]);
 
   // fetchCourses 함수를 ref로 관리하여 메모이제이션 사용
   const fetchCoursesRef = useRef(fetchCourses);
@@ -222,16 +224,20 @@ const useCourseRegistration = () => {
     fetchCoursesRef.current = fetchCourses;
   }, [fetchCourses]);
 
-  // 페이지 변경 핸들러
+  // 페이지 변경 핸들러 (fetchCoursesRef 사용하여 재생성 방지)
   const handlePageChange = useCallback((newPage) => {
     setPagination(prev => ({ ...prev, page: newPage }));
-    fetchCourses(newPage);
-  }, [fetchCourses]);
+    fetchCoursesRef.current(newPage);
+  }, []); // dependency 없음 - ref 사용
 
   // 장바구니 조회
   const fetchCarts = useCallback(async () => {
+    console.log('[API 호출] fetchCarts', { timestamp: new Date().toISOString() });
     try {
       const response = await getCarts();
+
+      console.log('[API 응답] fetchCarts', { response, timestamp: new Date().toISOString() });
+
       if (response.success && response.data?.courses) {
         const transformedCarts = response.data.courses.map(transformCartData);
         setCart(transformedCarts);
@@ -246,11 +252,35 @@ const useCourseRegistration = () => {
     }
   }, []);
 
+  // 수강신청 목록 조회
+  const fetchEnrollments = useCallback(async (periodId = null) => {
+    console.log('[API 호출] fetchEnrollments', { periodId, timestamp: new Date().toISOString() });
+    try {
+      const response = await getMyEnrollments(periodId || enrollmentPeriodId);
+
+      console.log('[API 응답] fetchEnrollments', { response, timestamp: new Date().toISOString() });
+
+      if (response.success && response.data?.enrollments) {
+        const transformedEnrollments = response.data.enrollments.map(transformEnrollmentData);
+        setRegistered(transformedEnrollments);
+      } else {
+        // 응답이 없거나 실패한 경우 빈 배열로 설정
+        setRegistered([]);
+      }
+    } catch (err) {
+      console.error('수강신청 목록 조회 실패:', err);
+      // 에러 발생 시에도 빈 배열로 설정하여 UI가 정상 작동하도록
+      setRegistered([]);
+    }
+  }, []);
+
   // 장바구니에 추가
   // 주의: 장바구니 추가는 정원이 꽉 차도 가능 (정원 체크 제외)
   // 검증 항목: 시간표 충돌, 학점 초과만 체크
   const addToCart = useCallback(async (course) => {
     try {
+      console.log('[API 호출] addToCart', { course, timestamp: new Date().toISOString() });
+
       // 이미 신청 완료된 강의인지 확인
       if (registered.find((c) => c.id === course.id)) {
         setToast({ open: true, message: '이미 수강신청이 완료된 강의입니다.', severity: 'warning' });
@@ -260,6 +290,19 @@ const useCourseRegistration = () => {
       // 이미 장바구니에 있는지 확인
       if (cart.find((c) => c.id === course.id)) {
         setToast({ open: true, message: '이미 장바구니에 추가된 강의입니다.', severity: 'warning' });
+        return;
+      }
+
+      // 동일 과목코드 다른 분반 체크 (장바구니 + 신청 완료 강의 모두 포함)
+      const duplicateSubject = [...cart, ...registered].find(
+        (c) => c.subjectCode === course.subjectCode && c.id !== course.id
+      );
+      if (duplicateSubject) {
+        setToast({ 
+          open: true, 
+          message: `[분반 중복] ${course.subjectName}(${course.subjectCode})는 이미 다른 분반이 장바구니에 있거나 수강신청되어 있습니다.`, 
+          severity: 'error' 
+        });
         return;
       }
 
@@ -293,16 +336,18 @@ const useCourseRegistration = () => {
       setLoading(true);
       setError(null);
 
-      // 현재 페이지 저장
-      const currentPage = pagination.page;
-
       const response = await addToCarts([course.id]);
 
       if (response.success) {
         // 장바구니 다시 조회
         await fetchCarts();
-        // 강의 목록도 다시 조회하여 isInCart 상태 업데이트 (현재 페이지 유지)
-        await fetchCourses(currentPage);
+        // 강의 목록에서 직접 isInCart 상태 업데이트 (불필요한 API 호출 제거)
+        setCourses(prevCourses => 
+          prevCourses.map(c => 
+            c.id === course.id ? { ...c, isInCart: true } : c
+          )
+        );
+        
         setToast({ open: true, message: `${course.subjectName}이(가) 장바구니에 추가되었습니다.`, severity: 'success' });
       } else {
         setToast({ open: true, message: response.message || '장바구니에 추가하는 중 오류가 발생했습니다.', severity: 'error' });
@@ -313,16 +358,14 @@ const useCourseRegistration = () => {
     } finally {
       setLoading(false);
     }
-  }, [cart, registered, pagination, fetchCarts, fetchCourses]);
+  }, [cart, registered, fetchCarts]);
 
   // 장바구니에서 제거
   const removeFromCart = useCallback(async (courseIdOrCartId) => {
     try {
+      console.log('[API 호출] removeFromCart', { courseIdOrCartId, timestamp: new Date().toISOString() });
       setLoading(true);
       setError(null);
-
-      // 현재 페이지 저장
-      const currentPage = pagination.page;
 
       // cartId 찾기 (courseId로도 찾을 수 있도록)
       const cartItem = cart.find((c) => c.id === courseIdOrCartId || c.cartId === courseIdOrCartId);
@@ -336,8 +379,12 @@ const useCourseRegistration = () => {
       if (response.success) {
         // 장바구니 다시 조회
         await fetchCarts();
-        // 강의 목록도 다시 조회하여 isInCart 상태 업데이트 (현재 페이지 유지)
-        await fetchCourses(currentPage);
+        // 강의 목록에서 직접 isInCart 상태 업데이트 (불필요한 API 호출 제거)
+        setCourses(prevCourses => 
+          prevCourses.map(c => 
+            c.id === cartItem.id ? { ...c, isInCart: false } : c
+          )
+        );
         setToast({ open: true, message: '장바구니에서 제거되었습니다.', severity: 'success' });
       } else {
         setToast({ open: true, message: response.message || '장바구니에서 제거하는 중 오류가 발생했습니다.', severity: 'error' });
@@ -348,11 +395,12 @@ const useCourseRegistration = () => {
     } finally {
       setLoading(false);
     }
-  }, [cart, pagination, fetchCarts, fetchCourses]);
+  }, [cart, fetchCarts]);
 
   // 장바구니 전체 제거
   const clearAllCarts = useCallback(async () => {
     try {
+      console.log('[API 호출] clearAllCarts', { timestamp: new Date().toISOString() });
       setLoading(true);
       setError(null);
 
@@ -361,8 +409,10 @@ const useCourseRegistration = () => {
       if (response.success) {
         // 장바구니 다시 조회
         await fetchCarts();
-        // 강의 목록도 다시 조회하여 isInCart 상태 업데이트
-        await fetchCourses(pagination.page);
+        // 강의 목록에서 직접 isInCart 상태 업데이트 (불필요한 API 호출 제거)
+        setCourses(prevCourses => 
+          prevCourses.map(c => ({ ...c, isInCart: false }))
+        );
         setToast({ open: true, message: '장바구니가 비워졌습니다.', severity: 'success' });
       } else {
         setToast({ open: true, message: response.message || '장바구니를 비우는 중 오류가 발생했습니다.', severity: 'error' });
@@ -373,7 +423,7 @@ const useCourseRegistration = () => {
     } finally {
       setLoading(false);
     }
-  }, [pagination, fetchCarts, fetchCourses]);
+  }, [fetchCarts]);
 
   // 수강신청 확정 (장바구니에서)
   const confirmRegistration = useCallback(async () => {
@@ -383,6 +433,8 @@ const useCourseRegistration = () => {
     }
 
     try {
+      console.log('[API 호출] confirmRegistration', { timestamp: new Date().toISOString() });
+      
       setLoading(true);
       setError(null);
 
@@ -405,13 +457,24 @@ const useCourseRegistration = () => {
           setRegistered(prev => [...prev, ...succeededCourses]);
         }
 
+        // 성공한 항목이 있으면 장바구니를 다시 조회 (서버에서 자동 제거됨)
+        if (succeeded.length > 0) {
+          await fetchCarts(); // 장바구니 다시 조회
+          await fetchEnrollments(enrollmentPeriodId); // 수강신청 목록 다시 조회
+          await fetchCourses(currentPage); // 강의 목록 다시 조회 (현재 페이지 유지)
+        }
+
+        // 결과 메시지 표시
         if (failed.length > 0) {
           const failedMessages = failed.map((f) => `${f.courseName}: ${f.message}`).join(', ');
-          setToast({ open: true, message: `일부 강의 수강신청에 실패했습니다: ${failedMessages}`, severity: 'error' });
+          setToast({ 
+            open: true, 
+            message: succeeded.length > 0 
+              ? `${succeeded.length}개 과목 수강신청 완료, 일부 실패: ${failedMessages}` 
+              : `수강신청 실패: ${failedMessages}`, 
+            severity: succeeded.length > 0 ? 'warning' : 'error' 
+          });
         } else {
-          // 모든 강의가 성공한 경우
-          await fetchCarts(); // 장바구니 다시 조회 (서버에서 자동 제거됨)
-          await fetchCourses(currentPage); // 강의 목록 다시 조회 (현재 페이지 유지)
           setToast({ open: true, message: '수강신청이 완료되었습니다.', severity: 'success' });
         }
       } else {
@@ -423,25 +486,39 @@ const useCourseRegistration = () => {
     } finally {
       setLoading(false);
     }
-  }, [cart, pagination, fetchCarts, fetchCourses]);
+  }, [cart, pagination, enrollmentPeriodId, fetchCarts, fetchCourses, fetchEnrollments]);
 
-  // 직접 수강신청 (개별 강의)
+  // 직접 수강신청 클릭 - 확인 다이얼로그 열기
+  const handleEnrollClick = useCallback((course) => {
+    setPendingEnrollCourse(course);
+    setEnrollDialogOpen(true);
+  }, []);
+
+  // 확인 다이얼로그 닫기
+  const handleEnrollDialogClose = useCallback(() => {
+    setEnrollDialogOpen(false);
+    setPendingEnrollCourse(null);
+  }, []);
+
+  // 직접 수강신청 (개별 강의) - 실제 신청 처리
   const handleEnroll = useCallback(async (course) => {
     try {
       // 이미 신청 완료된 강의인지 확인
       if (registered.find((c) => c.id === course.id)) {
         setToast({ open: true, message: '이미 수강신청이 완료된 강의입니다.', severity: 'warning' });
+        handleEnrollDialogClose();
         return;
       }
 
       // 클라이언트 측 검증: 정원 체크
       if (course.isFull || course.currentStudents >= course.maxStudents) {
         setToast({ open: true, message: '[정원 마감] 수강 정원이 마감되었습니다.', severity: 'error' });
+        handleEnrollDialogClose();
         return;
       }
 
-      // 클라이언트 측 검증: 시간표 충돌 체크 (장바구니 + 신청 완료 강의 모두 포함)
-      const existingCourses = [...cart, ...registered];
+      // 클라이언트 측 검증: 시간표 충돌 체크 (장바구니 + 신청 완료 강의 모두 포함, 단 동일 과목 제외)
+      const existingCourses = [...cart, ...registered].filter((c) => c.id !== course.id);
       const conflict = checkScheduleConflict(course, existingCourses);
       if (conflict.hasConflict) {
         const conflictingCourseName = conflict.conflictingCourse?.subjectName || '다른 강의';
@@ -450,11 +527,17 @@ const useCourseRegistration = () => {
           message: `[시간표 충돌] ${course.subjectName}의 시간표가 ${conflictingCourseName}와 충돌합니다.`, 
           severity: 'error' 
         });
+        handleEnrollDialogClose();
         return;
       }
 
-      // 클라이언트 측 검증: 학점 제한 체크 (장바구니 + 신청 완료 강의 모두 포함)
-      const currentTotalCredits = calculateTotalCredits([...cart, ...registered]);
+      // 클라이언트 측 검증: 학점 제한 체크
+      // 장바구니에 있는 과목을 직접 신청하는 경우, 장바구니에서 제거되므로 해당 과목의 학점은 제외하고 계산
+      const cartItem = cart.find((c) => c.id === course.id);
+      const coursesForCreditCheck = cartItem 
+        ? [...cart.filter((c) => c.id !== course.id), ...registered]  // 장바구니에 있으면 제외
+        : [...cart, ...registered];  // 장바구니에 없으면 그대로
+      const currentTotalCredits = calculateTotalCredits(coursesForCreditCheck);
       const newTotalCredits = currentTotalCredits + course.credits;
       if (isCreditLimitExceeded(currentTotalCredits, course.credits)) {
         const remainingCredits = 21 - currentTotalCredits;
@@ -463,6 +546,7 @@ const useCourseRegistration = () => {
           message: `[학점 초과] 최대 수강 가능 학점(21학점)을 초과합니다. (현재: ${currentTotalCredits}학점, 추가 시: ${newTotalCredits}학점, 남은 학점: ${remainingCredits}학점)`, 
           severity: 'error' 
         });
+        handleEnrollDialogClose();
         return;
       }
 
@@ -486,7 +570,8 @@ const useCourseRegistration = () => {
         if (failed.length > 0) {
           setToast({ open: true, message: failed[0].message || '수강신청에 실패했습니다.', severity: 'error' });
         } else {
-          await fetchCarts(); // 장바구니 다시 조회
+          await fetchCarts(); // 장바구니 다시 조회 (서버에서 자동 제거됨)
+          await fetchEnrollments(enrollmentPeriodId); // 수강신청 목록 다시 조회
           await fetchCourses(currentPage); // 강의 목록 다시 조회 (현재 페이지 유지)
           setToast({ open: true, message: `${course.subjectName} 수강신청이 완료되었습니다.`, severity: 'success' });
         }
@@ -498,8 +583,9 @@ const useCourseRegistration = () => {
       setToast({ open: true, message: err.response?.data?.message || err.message || '수강신청 중 오류가 발생했습니다.', severity: 'error' });
     } finally {
       setLoading(false);
+      handleEnrollDialogClose(); // 다이얼로그 닫기
     }
-  }, [cart, registered, pagination, fetchCarts, fetchCourses]);
+  }, [cart, registered, pagination, enrollmentPeriodId, fetchCarts, fetchCourses, fetchEnrollments, handleEnrollDialogClose]);
 
   // Enter 키 입력 시 즉시 검색
   const handleSearchKeyPress = useCallback((e) => {
@@ -509,11 +595,69 @@ const useCourseRegistration = () => {
     }
   }, [enrollmentPeriodId, fetchCourses]);
 
-  // 총 학점 계산
-  const totalCredits = cart.reduce((sum, course) => sum + course.credits, 0);
-  const registeredCredits = registered.reduce((sum, course) => sum + course.credits, 0);
+  // 수강신청 취소
+  const handleCancelEnrollment = useCallback(async (enrollmentId) => {
+    try {
+      setLoading(true);
+      setError(null);
 
-  return {
+      const currentPage = pagination.page;
+
+      const response = await cancelEnrollments([enrollmentId]);
+
+      if (response.success) {
+        const { cancelled = [], failed = [] } = response.data || {};
+        
+        if (cancelled.length > 0) {
+          // 취소된 강의를 registered에서 제거
+          setRegistered(prev => prev.filter(c => c.enrollmentId !== enrollmentId));
+          setToast({ open: true, message: '수강신청이 취소되었습니다.', severity: 'success' });
+        }
+
+        if (failed.length > 0) {
+          setToast({ open: true, message: failed[0].message || '수강신청 취소에 실패했습니다.', severity: 'error' });
+        } else {
+          // 취소 성공 시 목록 다시 조회
+          await fetchEnrollments(enrollmentPeriodId);
+          await fetchCourses(currentPage);
+        }
+      } else {
+        setToast({ open: true, message: response.message || '수강신청 취소 중 오류가 발생했습니다.', severity: 'error' });
+      }
+    } catch (err) {
+      console.error('수강신청 취소 실패:', err);
+      setToast({ open: true, message: err.response?.data?.message || err.message || '수강신청 취소 중 오류가 발생했습니다.', severity: 'error' });
+    } finally {
+      setLoading(false);
+    }
+  }, [pagination, enrollmentPeriodId, fetchEnrollments, fetchCourses]);
+
+  // 장바구니 학점 계산 (메모이제이션으로 불필요한 재계산 방지)
+  const cartCredits = useMemo(() => 
+    cart.reduce((sum, course) => sum + course.credits, 0), 
+    [cart]
+  );
+  const registeredCredits = useMemo(() => 
+    registered.reduce((sum, course) => sum + course.credits, 0), 
+    [registered]
+  );
+
+  // pagination 객체 메모이제이션 (참조 안정화)
+  const memoizedPagination = useMemo(() => pagination, [
+    pagination.page,
+    pagination.size,
+    pagination.total,
+    pagination.totalPages,
+  ]);
+
+  // toast를 ref로 관리하여 리렌더링 방지
+  const toastRef = useRef(toast);
+  useEffect(() => {
+    toastRef.current = toast;
+  }, [toast]);
+
+  // 반환 객체를 완전히 메모이제이션하여 리렌더링 방지
+  const stableReturn = useMemo(() => ({
     // 상태
     tabValue,
     setTabValue,
@@ -530,8 +674,8 @@ const useCourseRegistration = () => {
     courses,
     loading,
     error,
-    pagination,
-    totalCredits,
+    pagination: memoizedPagination,
+    cartCredits,
     registeredCredits,
     
     // 핸들러
@@ -541,12 +685,53 @@ const useCourseRegistration = () => {
     clearAllCarts,
     confirmRegistration,
     handleSearchKeyPress,
-    handleEnroll,
+    handleEnrollClick,  // 확인 다이얼로그 열기
+    handleEnroll,        // 실제 신청 처리
+    handleEnrollDialogClose,  // 다이얼로그 닫기
+    handleCancelEnrollment,
     setError,
-    // 토스트
-    toast,
     setToast,
-  };
+    // 다이얼로그 상태
+    enrollDialogOpen,
+    pendingEnrollCourse,
+    // toast ref (리렌더링 방지)
+    toastRef,
+  }), [
+    tabValue,
+    setTabValue,
+    searchTerm,
+    setSearchTerm,
+    selectedDepartment,
+    setSelectedDepartment,
+    selectedCourseType,
+    setSelectedCourseType,
+    selectedCredits,
+    setSelectedCredits,
+    cart,
+    registered,
+    courses,
+    loading,
+    error,
+    memoizedPagination,
+    cartCredits,
+    registeredCredits,
+    handlePageChange,
+    addToCart,
+    removeFromCart,
+    clearAllCarts,
+    confirmRegistration,
+    handleSearchKeyPress,
+    handleEnrollClick,
+    handleEnroll,
+    handleEnrollDialogClose,
+    handleCancelEnrollment,
+    setError,
+    setToast,
+    enrollDialogOpen,
+    pendingEnrollCourse,
+  ]);
+
+  return stableReturn;
 };
 
 export default useCourseRegistration;

--- a/src/domains/course/transformers/courseTransformers.js
+++ b/src/domains/course/transformers/courseTransformers.js
@@ -1,0 +1,77 @@
+/**
+ * API 응답 데이터를 UI 형식으로 변환하는 함수들
+ */
+
+/**
+ * 강의 목록 API 응답 데이터를 UI 형식으로 변환
+ * @param {Object} apiCourse - API 응답의 강의 데이터
+ * @returns {Object} UI에서 사용할 강의 데이터
+ */
+export const transformCourseData = (apiCourse) => {
+  return {
+    id: apiCourse.id,
+    subjectCode: apiCourse.courseCode,
+    subjectName: apiCourse.courseName,
+    professor: apiCourse.professor?.name || '',
+    department: apiCourse.department?.name || '',
+    departmentId: apiCourse.department?.id || null,
+    courseType: apiCourse.courseType?.name || '',
+    courseTypeCode: apiCourse.courseType?.code || '',
+    credits: apiCourse.credits,
+    currentStudents: apiCourse.enrollment?.current || 0,
+    maxStudents: apiCourse.enrollment?.max || 0,
+    isFull: apiCourse.enrollment?.isFull || false,
+    schedule: apiCourse.schedule || [],
+    classroom: apiCourse.schedule?.[0]?.classroom || '',
+    isInCart: apiCourse.isInCart || false,
+    isEnrolled: apiCourse.isEnrolled || false,
+    canEnroll: apiCourse.canEnroll, // API 응답값 그대로 사용
+  };
+};
+
+/**
+ * 장바구니 API 응답 데이터를 UI 형식으로 변환
+ * @param {Object} cartItem - API 응답의 장바구니 아이템 데이터
+ * @returns {Object} UI에서 사용할 장바구니 아이템 데이터
+ */
+export const transformCartData = (cartItem) => {
+  return {
+    cartId: cartItem.cartId,
+    id: cartItem.course?.id,
+    subjectCode: cartItem.course?.code,
+    subjectName: cartItem.course?.name,
+    professor: cartItem.professor?.name || '',
+    credits: cartItem.course?.credits || 0,
+    courseType: cartItem.course?.courseType || '',
+    schedule: cartItem.schedule || [],
+    classroom: cartItem.schedule?.[0]?.classroom || '',
+    currentStudents: cartItem.enrollment?.current || 0,
+    maxStudents: cartItem.enrollment?.max || 0,
+    isFull: cartItem.enrollment?.isFull || false,
+    addedAt: cartItem.addedAt,
+  };
+};
+
+/**
+ * 수강신청 API 응답 데이터를 UI 형식으로 변환
+ * @param {Object} enrollmentItem - API 응답의 수강신청 아이템 데이터
+ * @returns {Object} UI에서 사용할 수강신청 아이템 데이터
+ */
+export const transformEnrollmentData = (enrollmentItem) => {
+  return {
+    enrollmentId: enrollmentItem.enrollmentId,
+    id: enrollmentItem.course?.id,
+    subjectCode: enrollmentItem.course?.courseCode,
+    subjectName: enrollmentItem.course?.courseName,
+    professor: enrollmentItem.professor?.name || '',
+    credits: enrollmentItem.course?.credits || 0,
+    courseType: enrollmentItem.course?.courseType?.name || '',
+    schedule: enrollmentItem.schedule || [],
+    classroom: enrollmentItem.schedule?.[0]?.classroom || '',
+    canCancel: enrollmentItem.canCancel || false,
+    currentStudents: enrollmentItem.course?.currentStudents || 0,
+    maxStudents: enrollmentItem.course?.maxStudents || 0,
+    isFull: enrollmentItem.course?.currentStudents >= enrollmentItem.course?.maxStudents || false,
+  };
+};
+

--- a/src/pages/CourseRegistration.jsx
+++ b/src/pages/CourseRegistration.jsx
@@ -15,16 +15,13 @@
 import React from 'react';
 import {
   Box,
-  Grid,
   Paper,
   Typography,
   Tabs,
   Tab,
   Chip,
   Alert,
-  Snackbar,
 } from '@mui/material';
-import MuiAlert from '@mui/material/Alert';
 
 // 컴포넌트
 import TabPanel from '../domains/course/components/TabPanel';
@@ -34,6 +31,7 @@ import CourseListTable from '../domains/course/components/CourseListTable';
 import CartTab from '../domains/course/components/CartTab';
 import RegisteredTab from '../domains/course/components/RegisteredTab';
 import EnrollmentSummary from '../domains/course/components/EnrollmentSummary';
+import ToastManager from '../domains/course/components/ToastManager';
 
 // 커스텀 훅
 import useCourseRegistration from '../domains/course/hooks/useCourseRegistration';
@@ -59,7 +57,7 @@ const CourseRegistration = () => {
     loading,
     error,
     pagination,
-    totalCredits,
+    cartCredits,
     registeredCredits,
     handlePageChange,
     addToCart,
@@ -68,10 +66,16 @@ const CourseRegistration = () => {
     confirmRegistration,
     handleSearchKeyPress,
     handleEnroll,
+    handleCancelEnrollment,
     setError,
-    toast,
-    setToast,
+    // 수강신청 확인 다이얼로그 상태
+    enrollDialogOpen,
+    pendingEnrollCourse,
+    handleEnrollClick,
+    handleEnrollDialogClose,
+    toastRef, // toast ref (리렌더링 방지)
   } = useCourseRegistration();
+
 
   return (
     <Box sx={{ width: '100%', maxWidth: '100%', mx: 'auto' }}>
@@ -148,7 +152,12 @@ const CourseRegistration = () => {
                 registered={registered}
                 onAddToCart={addToCart}
                 onRemoveFromCart={removeFromCart}
-                onEnroll={handleEnroll}
+                onEnroll={handleEnrollClick}
+                onEnrollConfirm={handleEnroll}
+                onEnrollDialogClose={handleEnrollDialogClose}
+                enrollDialogOpen={enrollDialogOpen}
+                pendingEnrollCourse={pendingEnrollCourse}
+                onCancelEnrollment={handleCancelEnrollment}
               />
             </TabPanel>
 
@@ -156,7 +165,7 @@ const CourseRegistration = () => {
             <TabPanel value={tabValue} index={1}>
               <CartTab
                 cart={cart}
-                totalCredits={totalCredits}
+                cartCredits={cartCredits}
                 registeredCredits={registeredCredits}
                 onRemoveFromCart={removeFromCart}
                 onClearAllCarts={clearAllCarts}
@@ -166,7 +175,10 @@ const CourseRegistration = () => {
 
             {/* 신청 완료 탭 */}
             <TabPanel value={tabValue} index={2}>
-              <RegisteredTab registered={registered} />
+              <RegisteredTab 
+                registered={registered}
+                onCancelEnrollment={handleCancelEnrollment}
+              />
             </TabPanel>
           </Paper>
 
@@ -185,7 +197,7 @@ const CourseRegistration = () => {
           <Box sx={{ flex: 0.8  }}>
             <EnrollmentSummary
               registeredCredits={registeredCredits}
-              totalCredits={totalCredits}
+              cartCredits={cartCredits}
               registeredCount={registered.length}
               cartCount={cart.length}
             />
@@ -193,21 +205,8 @@ const CourseRegistration = () => {
         </Box>
       </Box>
 
-      {/* 토스트 메시지 */}
-      <Snackbar
-        open={toast.open}
-        autoHideDuration={4000}
-        onClose={() => setToast({ ...toast, open: false })}
-        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-      >
-        <MuiAlert
-          onClose={() => setToast({ ...toast, open: false })}
-          severity={toast.severity}
-          sx={{ width: '100%' }}
-        >
-          {toast.message}
-        </MuiAlert>
-      </Snackbar>
+      {/* 토스트 메시지 (별도 컴포넌트로 분리하여 리렌더링 방지) */}
+      <ToastManager toastRef={toastRef} />
     </Box>
   );
 };


### PR DESCRIPTION


목적

- 왜 이 PR이 필요한가? (관련 Story/Epic/CR 링크)
#3 

변경 요약

수강신청 기능 구현.
이제 수강신청 버튼을 누르면 enrollments 테이블에 데이터가 들어감

- 핵심 변경
- 
수강신청 된 과목은 시간표 미리보기에 파란계열, 장바구니는 주황색 계열로 표시됨.
개설 과목 탭에서 선수과목 안들어서 들을 수 없는건 장바구니, 신청 버튼 안보임
키워드 검색은 500ms 디바운스 줘서 과도한 백엔드 쿼리를 막음. 엔터 누르면 바로 검색.

페이징 기본 사이즈는 10. 개설 과목 쪽에만 페이징 처리함.

장바구니 탭에서 일괄 수강신청이 존재.
신청, 제거 할 땐 확인 다이얼로그가 한 번씩 뜸.

- 주요 파일/모듈
src/domains/course
