### PR TITLE
#81 댓글/대댓글 알림 타입 지원 추가

### DIFF
--- a/src/components/NotificationDetailDialog.jsx
+++ b/src/components/NotificationDetailDialog.jsx
@@ -25,6 +25,8 @@ import {
   EventNote as EventNoteIcon,
   Info as InfoIcon,
   OpenInNew as OpenInNewIcon,
+  ChatBubble as ChatBubbleIcon,
+  Reply as ReplyIcon,
 } from '@mui/icons-material';
 import notificationService from '../services/notificationService';
 
@@ -59,6 +61,8 @@ const NotificationDetailDialog = ({
       LECTURE: <SchoolIcon />,
       ATTENDANCE: <EventNoteIcon />,
       SYSTEM: <InfoIcon />,
+      COMMENT_CREATED: <ChatBubbleIcon />,
+      REPLY_CREATED: <ReplyIcon />,
     };
     return icons[type] || <InfoIcon />;
   };
@@ -73,6 +77,8 @@ const NotificationDetailDialog = ({
       LECTURE: 'secondary',
       ATTENDANCE: 'warning',
       SYSTEM: 'default',
+      COMMENT_CREATED: 'info',
+      REPLY_CREATED: 'info',
     };
     return colors[type] || 'default';
   };

--- a/src/pages/Notifications.jsx
+++ b/src/pages/Notifications.jsx
@@ -39,6 +39,8 @@ import {
   DoneAll as DoneAllIcon,
   DeleteSweep as DeleteSweepIcon,
   Refresh as RefreshIcon,
+  ChatBubble as ChatBubbleIcon,
+  Reply as ReplyIcon,
 } from '@mui/icons-material';
 import { alpha } from '@mui/material/styles';
 import notificationService from '../services/notificationService';
@@ -70,6 +72,8 @@ const Notifications = () => {
       LECTURE: <SchoolIcon />,
       ATTENDANCE: <EventNoteIcon />,
       SYSTEM: <InfoIcon />,
+      COMMENT_CREATED: <ChatBubbleIcon />,
+      REPLY_CREATED: <ReplyIcon />,
     };
     return icons[type] || <NotificationsIcon />;
   };
@@ -84,6 +88,8 @@ const Notifications = () => {
       LECTURE: 'secondary',
       ATTENDANCE: 'warning',
       SYSTEM: 'default',
+      COMMENT_CREATED: 'info',
+      REPLY_CREATED: 'info',
     };
     return colors[type] || 'default';
   };

--- a/src/services/notificationService.js
+++ b/src/services/notificationService.js
@@ -96,6 +96,8 @@ const notificationService = {
       LECTURE: '강의',
       ATTENDANCE: '출석',
       SYSTEM: '시스템',
+      COMMENT_CREATED: '댓글',
+      REPLY_CREATED: '답글',
     };
     return typeLabels[type] || '알림';
   },


### PR DESCRIPTION
## Summary
- 백엔드에서 추가된 COMMENT_CREATED, REPLY_CREATED 알림 타입을 프론트엔드에서 지원
- 알림 타입 라벨, 아이콘, 색상 매핑 추가

## 변경 파일
- `src/services/notificationService.js` - 타입 라벨 추가
- `src/pages/Notifications.jsx` - 아이콘/색상 매핑 추가
- `src/components/NotificationDetailDialog.jsx` - 아이콘/색상 매핑 추가

## Test plan
- [ ] 댓글 알림 수신 시 아이콘(ChatBubbleIcon) 및 라벨(댓글) 표시 확인
- [ ] 대댓글 알림 수신 시 아이콘(ReplyIcon) 및 라벨(답글) 표시 확인
- [ ] 알림 상세보기에서 타입별 색상 표시 확인