### PR TITLE
#85 교수 사이드바에 메시지 메뉴 추가

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -204,6 +204,13 @@ const professorMenuItems = [
     divider: true, // 구분선
   },
   {
+    title: '메시지',
+    path: '/messages',
+    icon: <MailIcon />,
+    description: '쪽지 보내기/받기',
+    hasBadge: true, // 동적 뱃지 표시 플래그
+  },
+  {
     title: '내 정보',
     path: '/profile',
     icon: <PersonIcon />,


### PR DESCRIPTION
## Summary
- 교수 유저도 사이드바에서 메시지 기능에 접근 가능하도록 메뉴 추가
- 학생용과 동일하게 읽지 않은 메시지 수 뱃지 표시

## 변경 사항
- `professorMenuItems`에 메시지 메뉴 항목 추가 (`src/components/Sidebar.jsx`)

## Test plan
- [ ] 교수 계정으로 로그인 후 사이드바에 메시지 메뉴 표시 확인
- [ ] 메시지 메뉴 클릭 시 `/messages` 페이지로 이동 확인
- [ ] 읽지 않은 메시지가 있을 때 뱃지 표시 확인

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)